### PR TITLE
Selenium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.mypy_cache/
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following calls are supported, which correspond to a page in LCR:
 - Members moved in
 - Member list
 - Calling list
+- Recommend Status
 
 There is one additional call supported:
 

--- a/lcr/__init__.py
+++ b/lcr/__init__.py
@@ -156,3 +156,17 @@ class API():
         result = self._make_request(request)
         return result.json()
 
+    def recommend_status(self):
+        """
+        Obtain member information on recommend status
+        """
+        _LOGGER.info("Getting recommend status")
+        request = {
+                'url': 'https://{}/services/recommend/recommend-status'.format(LCR_DOMAIN),
+                'params': {
+                    'lang': 'eng',
+                    'unitNumber': self.unit_number
+                    }
+                }
+        result = self._make_request(request)
+        return result.json()

--- a/lcr/__init__.py
+++ b/lcr/__init__.py
@@ -91,7 +91,7 @@ class API():
 
     def member_list(self):
         _LOGGER.info("Getting member list")
-        request = {'url': 'https://{}/services/report/member-list'.format(LCR_DOMAIN),
+        request = {'url': 'https://{}/services/umlu/report/member-list'.format(LCR_DOMAIN),
                    'params': {'lang': 'eng',
                               'unitNumber': self.unit_number}}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest==2.9.1
 requests==2.20.0
+selenium

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -102,3 +102,23 @@ class Test:
                          "fullTimeMissionary", "address", "age"}
         actual_keys = set(member.keys())
         self.check_keys(expected_keys, actual_keys)
+
+    def test_recommend_status(self):
+        recommend_status = Test.cd.recommend_status()
+
+        assert isinstance(recommend_status, list)
+
+        member = recommend_status[0]
+        assert isinstance(member, dict)
+
+        expected_keys = {
+                "name", "spokenName", "nameOrder", "birthDate", "birthDateSort", "gender", "genderCode",
+                "mrn", "id", "email", "householdEmail", "phone", "householdPhone", "unitNumber",
+                "unitName", "priesthood", "priesthoodCode", "priesthoodType", "age", "actualAge", "actualAgeInMonths",
+                "genderLabelShort", "visible", "nonMember", "outOfUnitMember", "marriageDate", "endowmentDate", "expirationDate",
+                "status", "recommendStatus", "type", "unordained", "notBaptized", "recommendEditable", "recommendStatusSimple",
+                "formattedMrn", "setApart", "sustainedDate"
+                }
+
+        actual_keys = set(member.keys())
+        self.check_keys(expected_keys, actual_keys)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -34,7 +34,8 @@ class Test:
                          "householdEmail", "phone", "spokenName", "name",
                          "setApart", "priesthoodCode", "priesthoodType",
                          "nameOrder", "householdPhone", "genderLabelShort",
-                         "id", "unitName", "outOfUnitMember", "displayBirthdate"}
+                         "id", "unitName", "outOfUnitMember", "displayBirthdate",
+                         "birthDayFormatted", "birthDaySort", "birthDateFormatted"}
         actual_keys = set(birthday.keys())
         self.check_keys(expected_keys, actual_keys)
 
@@ -45,18 +46,13 @@ class Test:
         movein = moveins[0]
         assert isinstance(movein, dict)
 
-        expected_keys = {"genderCode", "priesthoodCode", "hohMrn", "visible",
-                         "age", "gender", "actualAgeInMonths",
-                         "outOfUnitMember", "moveDateOrder", "priesthood",
-                         "householdPosition", "email", "unitName",
-                         "priorUnitName", "unitNumber", "priesthoodType",
-                         "nameOrder", "address", "deceased", "name",
-                         "birthDateSort", "nonMember", "householdPhone",
-                         "genderLabelShort", "priorUnit", "setApart",
-                         "textAddress", "id", "actualAge", "moveDate",
-                         "householdEmail", "addressUnknown", "spokenName",
-                         "birthDate", "sustainedDate", "mrn", "formattedMrn",
-                         "phone"}
+        expected_keys = {"gender", "phone", "moveDateCalc", "nameOrder",
+                         "genderLabelShort", "priesthood", "addressUnknown",
+                         "birthdate", "birthdateCalc", "moveDate", "unitName",
+                         "priorUnitNumber", "address", "id", "householdPositionEnum",
+                         "priorUnitName", "moveDateOrder", "textAddress", "locale",
+                         "householdUuid", "householdPosition", "name", "age"}
+
         actual_keys = set(movein.keys())
         self.check_keys(expected_keys, actual_keys)
 
@@ -69,7 +65,8 @@ class Test:
 
         expected_keys = {"deceased", "nextUnitNumber", "name", "nextUnitName",
                          "addressUnknown", "moveDate", "priorUnit",
-                         "moveDateOrder", "birthDate", "nameOrder"}
+                         "moveDateOrder", "birthDate", "nameOrder",
+                         "moveDateDisplay", "birthDateDisplay"}
         actual_keys = set(moveout.keys())
         self.check_keys(expected_keys, actual_keys)
 
@@ -91,15 +88,21 @@ class Test:
         member = member_list[0]
         assert isinstance(member, dict)
 
-        expected_keys = {"outOfUnitMember", "setApart", "priesthoodCode", "id", "name",
-                         "gender", "formattedMrn", "isSpouse", "sustainedDate", "mrn",
-                         "unitName", "priesthoodType", "spokenName", "householdPhone",
-                         "visible", "priesthood", "nonMember", "isAdult", "birthDateSort",
-                         "isHead", "birthDate", "genderLabelShort",
-                         "genderCode", "actualAge", "phone", "householdEmail",
-                         "actualAgeInMonths", "householdId", "coupleName",
-                         "nameOrder", "givenName", "email", "unitNumber",
-                         "fullTimeMissionary", "address", "age"}
+        expected_keys = {"isMember", "isSpouse", "householdRole",
+                         "householdPhoneNumber", "nameGivenPreferredLocal",
+                         "nameListPreferredLocal", "sex", "isAdult", "nameFormats",
+                         "priesthoodOffice", "isHead", "birth",
+                         "householdNameFamilyLocal", "isProspectiveElder",
+                         "unitOrgsCombined", "unitName", "outOfUnitMember",
+                         "householdUuid", "householdEmail", "householdAnchorPersonUuid",
+                         "personStatusFlags", "unitNumber", "householdMember",
+                         "formattedAddress", "phoneNumber", "membershipUnit",
+                         "youthBasedOnAge", "nameOrder", "emails", "age", "email",
+                         "member", "houseHoldMemberNameForList", "personUuid",
+                         "householdNameDirectoryLocal", "priesthoodTeacherOrAbove",
+                         "convert", "isOutOfUnitMember", "isSingleAdult",
+                         "isYoungSingleAdult", "uuid", "phones", "address",
+                         "nameFamilyPreferredLocal", "legacyCmisId"}
         actual_keys = set(member.keys())
         self.check_keys(expected_keys, actual_keys)
 
@@ -111,14 +114,17 @@ class Test:
         member = recommend_status[0]
         assert isinstance(member, dict)
 
-        expected_keys = {
-                "name", "spokenName", "nameOrder", "birthDate", "birthDateSort", "gender", "genderCode",
-                "mrn", "id", "email", "householdEmail", "phone", "householdPhone", "unitNumber",
-                "unitName", "priesthood", "priesthoodCode", "priesthoodType", "age", "actualAge", "actualAgeInMonths",
-                "genderLabelShort", "visible", "nonMember", "outOfUnitMember", "marriageDate", "endowmentDate", "expirationDate",
-                "status", "recommendStatus", "type", "unordained", "notBaptized", "recommendEditable", "recommendStatusSimple",
-                "formattedMrn", "setApart", "sustainedDate"
-                }
+        expected_keys = { "name", "spokenName", "nameOrder", "birthDate",
+                          "birthDateSort", "gender", "genderCode", "mrn", "id", "email",
+                          "householdEmail", "phone", "householdPhone", "unitNumber",
+                          "unitName", "priesthood", "priesthoodCode", "priesthoodType",
+                          "age", "actualAge", "actualAgeInMonths", "genderLabelShort",
+                          "visible", "nonMember", "outOfUnitMember", "marriageDate",
+                          "endowmentDate", "expirationDate", "status", "recommendStatus",
+                          "type", "unordained", "notBaptized", "recommendEditable",
+                          "recommendStatusSimple", "formattedMrn", "setApart",
+                          "sustainedDate", "birthDaySort", "birthDateFormatted",
+                          "birthDayFormatted" }
 
         actual_keys = set(member.keys())
         self.check_keys(expected_keys, actual_keys)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -26,16 +26,18 @@ class Test:
         birthday = birthdays[0]
         assert isinstance(birthday, dict)
 
-        expected_keys = {"unitNumber", "formattedMrn", "priesthood", "mrn",
-                         "actualAge", "actualAgeInMonths", "monthInteger",
-                         "email", "genderCode", "birthDateSort", "age",
-                         "birthDayAge", "birthDate", "nonMember", "visible",
-                         "gender", "dayInteger", "address", "sustainedDate",
-                         "householdEmail", "phone", "spokenName", "name",
-                         "setApart", "priesthoodCode", "priesthoodType",
-                         "nameOrder", "householdPhone", "genderLabelShort",
-                         "id", "unitName", "outOfUnitMember", "displayBirthdate",
-                         "birthDayFormatted", "birthDaySort", "birthDateFormatted"}
+        expected_keys = {
+                'name', 'spokenName', 'nameOrder', 'birthDate',
+                'birthDateSort', 'birthDaySort', 'birthDayFormatted',
+                'birthDateFormatted', 'gender', 'genderCode', 'mrn', 'id',
+                'email', 'householdEmail', 'phone', 'householdPhone',
+                'unitNumber', 'unitName', 'priesthood', 'priesthoodCode',
+                'priesthoodType', 'age', 'actualAge', 'actualAgeInMonths',
+                'genderLabelShort', 'visible', 'nonMember', 'outOfUnitMember',
+                'notAccountable', 'address', 'monthInteger', 'dayInteger',
+                'birthDayAge', 'displayBirthdate', 'sustainedDate',
+                'formattedMrn', 'setApart', 'accountable'
+                }
         actual_keys = set(birthday.keys())
         self.check_keys(expected_keys, actual_keys)
 
@@ -87,21 +89,23 @@ class Test:
         member = member_list[0]
         assert isinstance(member, dict)
 
-        expected_keys = {"isMember", "isSpouse", "householdRole",
-                         "householdPhoneNumber", "nameGivenPreferredLocal",
-                         "nameListPreferredLocal", "sex", "isAdult", "nameFormats",
-                         "priesthoodOffice", "isHead", "birth",
-                         "householdNameFamilyLocal", "isProspectiveElder",
-                         "unitOrgsCombined", "unitName", "outOfUnitMember",
-                         "householdUuid", "householdEmail", "householdAnchorPersonUuid",
-                         "personStatusFlags", "unitNumber", "householdMember",
-                         "formattedAddress", "phoneNumber", "membershipUnit",
-                         "youthBasedOnAge", "nameOrder", "emails", "age", "email",
-                         "member", "houseHoldMemberNameForList", "personUuid",
-                         "householdNameDirectoryLocal", "priesthoodTeacherOrAbove",
-                         "convert", "isOutOfUnitMember", "isSingleAdult",
-                         "isYoungSingleAdult", "uuid", "phones", "address",
-                         "nameFamilyPreferredLocal", "legacyCmisId"}
+        expected_keys = {
+                'nameFormats', 'uuid', 'nameOrder', 'age', 'emails', 'phones',
+                'phoneNumber', 'priesthoodOffice', 'membershipUnit',
+                'legacyCmisId', 'sex', 'unitOrgsCombined', 'positions',
+                'householdMember', 'householdEmail', 'formattedAddress',
+                'isMember', 'householdUuid', 'isProspectiveElder',
+                'isSingleAdult', 'isYoungSingleAdult', 'householdPhoneNumber',
+                'isHead', 'priesthoodTeacherOrAbove', 'convert', 'member',
+                'unitName', 'youthBasedOnAge', 'isSpouse', 'unitNumber',
+                'outOfUnitMember', 'nameGivenPreferredLocal',
+                'houseHoldMemberNameForList', 'isOutOfUnitMember', 'isAdult',
+                'nameFamilyPreferredLocal', 'householdAnchorPersonUuid',
+                'householdNameFamilyLocal', 'householdRole', 'personUuid',
+                'nameListPreferredLocal', 'householdNameDirectoryLocal',
+                'email', 'address', 'birth', 'personStatusFlags'
+                }
+
         actual_keys = set(member.keys())
         self.check_keys(expected_keys, actual_keys)
 
@@ -113,17 +117,20 @@ class Test:
         member = recommend_status[0]
         assert isinstance(member, dict)
 
-        expected_keys = { "name", "spokenName", "nameOrder", "birthDate",
-                          "birthDateSort", "gender", "genderCode", "mrn", "id", "email",
-                          "householdEmail", "phone", "householdPhone", "unitNumber",
-                          "unitName", "priesthood", "priesthoodCode", "priesthoodType",
-                          "age", "actualAge", "actualAgeInMonths", "genderLabelShort",
-                          "visible", "nonMember", "outOfUnitMember", "marriageDate",
-                          "endowmentDate", "expirationDate", "status", "recommendStatus",
-                          "type", "unordained", "notBaptized", "recommendEditable",
-                          "recommendStatusSimple", "formattedMrn", "setApart",
-                          "sustainedDate", "birthDaySort", "birthDateFormatted",
-                          "birthDayFormatted" }
+        expected_keys = {
+                'name', 'spokenName', 'nameOrder', 'birthDate',
+                'birthDateSort', 'birthDaySort', 'birthDayFormatted',
+                'birthDateFormatted', 'gender', 'genderCode', 'mrn', 'id',
+                'email', 'householdEmail', 'phone', 'householdPhone',
+                'unitNumber', 'unitName', 'priesthood', 'priesthoodCode',
+                'priesthoodType', 'age', 'actualAge', 'actualAgeInMonths',
+                'genderLabelShort', 'visible', 'nonMember', 'outOfUnitMember',
+                'notAccountable', 'marriageDate', 'endowmentDate',
+                'expirationDate', 'status', 'recommendStatus', 'type',
+                'unordained', 'notBaptized', 'recommendStatusSimple',
+                'recommendEditable', 'formattedMrn', 'sustainedDate',
+                'accountable', 'setApart'
+                }
 
         actual_keys = set(member.keys())
         self.check_keys(expected_keys, actual_keys)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -65,8 +65,7 @@ class Test:
 
         expected_keys = {"deceased", "nextUnitNumber", "name", "nextUnitName",
                          "addressUnknown", "moveDate", "priorUnit",
-                         "moveDateOrder", "birthDate", "nameOrder",
-                         "moveDateDisplay", "birthDateDisplay"}
+                         "moveDateOrder", "birthDate", "nameOrder"}
         actual_keys = set(moveout.keys())
         self.check_keys(expected_keys, actual_keys)
 


### PR DESCRIPTION
This pull request addresses #11 by updating the API's `__init__` function to authenticate using a headless browser using selenium. The selenium WebDriver can be supplied as one of the arguments to the `__init__` function, though the default uses of headless chrome browser.

All tests have been updated to the key lists that are currently returned to ensure tests pass. 